### PR TITLE
Verify that the cached excerpts include all crawls

### DIFF
--- a/get_stats.sh
+++ b/get_stats.sh
@@ -6,8 +6,9 @@ if aws s3 ls s3://commoncrawl/crawl-analysis/ | sed -E 's@.* @@; s@/$@@' >./stat
     ON_AWS=true;
     echo "Running on AWS (AWS CLI configured for authenticated access)"
 else
-    # extracting list of crawls from Python enum definition
-    grep -Eo 'CC-MAIN-20[0-9][0-9]-[0-9]+' crawlstats.py | sort -u >./stats/crawls.txt
+    echo "Downloading from https://data.commoncrawl.org/ using curl"
+    # list of crawls enumerated in crawlstats.py
+    python3 -c 'from crawlstats import MonthlyCrawl; [print(c) for c in sorted(MonthlyCrawl.by_name.keys())]' >./stats/crawls.txt
     ON_AWS=false
 fi
 


### PR DESCRIPTION
The crawl statistics files grow large over time and the cached excerpts speed up the plotting significantly because
the all-in-one statistics files are split by topic, so that the ten plotting scripts do not need to read all data entirely and skip unneeded metrics.

This requires that the excerpt are complete. So far, the script plot.sh only appended the latest crawl to an existing excerpt without verifying the all of the previous crawls are there. This works if you run the plotting script always on the same instance or the first time an a new instance. However, it fails if the script is run sometimes but not every month on the same machine.

To overcome this limitation:
- add check that all crawls included in a cached excerpt
- if not, build the excerpt anew
- reliably list registered crawl datasets
- add more verbose logging
  - number of crawls registered and statistics files available/processed
  - the latest crawl
  - log success of the plotting script
