### PR TITLE
feat: Change default plot library to matplotlib

### DIFF
--- a/crawlplot.py
+++ b/crawlplot.py
@@ -204,7 +204,7 @@ class CrawlPlot:
     def __init__(self):
         """Initialize the plot with library selection and output directory setup."""
         # Settings defined via environment variables
-        self.PLOTLIB: PlotLibType = os.environ.get('PLOTLIB', 'rpy2.ggplot2')
+        self.PLOTLIB: PlotLibType = os.environ.get('PLOTLIB', 'matplotlib')
         self.PLOTDIR = os.environ.get('PLOTDIR', 'plots')
 
         if self.PLOTLIB == 'ggplot':

--- a/stats.Dockerfile
+++ b/stats.Dockerfile
@@ -39,8 +39,11 @@ COPY *.sh ./
 COPY *.py ./
 COPY _config.yml ./
 
-# Set PYTHONPATH environment variable
+# Set environment variables
 ENV PYTHONPATH=/app
+
+# Supported plotlibs: matplotlib, rpy2.ggplot2, ggplot (partially deprecated)
+ENV PLOTLIB=matplotlib
 
 # ggplot2 is already installed via r-cran-ggplot2 system package above
 


### PR DESCRIPTION
This PR changes the default plotting library from `rpy2.ggplot2` to `matplotlib`.

See https://github.com/commoncrawl/cc-crawl-statistics/pull/25