### PR TITLE
feat: Updated CI for multi platform builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI Pipeline
 
 on:
   push:
+    branches: [master]
   pull_request:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Log in to Container Registry
       uses: docker/login-action@v3
       with:
@@ -42,11 +48,10 @@ jobs:
       with:
         context: .
         file: ./stats.Dockerfile
-        push: false
+        load: true
+        platforms: linux/amd64
         tags: |
           ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/stats:${{ github.sha }}
-          ${{ steps.meta-stats.outputs.tags }}
-        labels: ${{ steps.meta-stats.outputs.labels }}
 
     - name: Run unit tests
       run: |
@@ -66,6 +71,7 @@ jobs:
         context: .
         file: ./stats.Dockerfile
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta-stats.outputs.tags }}
         labels: ${{ steps.meta-stats.outputs.labels }}
 


### PR DESCRIPTION
This PR enables building container images for `linux/amd64` and `linux/arm64` platforms. Fixes https://github.com/commoncrawl/cc-crawl-statistics/issues/27

Verified on MacOS:

```
$ uname -p
arm

$ podman pull ghcr.io/commoncrawl/cc-crawl-statistics/stats:pr-28 

$ podman inspect ghcr.io/commoncrawl/cc-crawl-statistics/stats:pr-28 | grep Architecture
          "Architecture": "arm64",
```         
          