### PR TITLE
feat: add GitHub Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: "hyperloglog"
+        # needs to stay on 0.0.14 to avoid serialization errors, see #15
+        versions: [ ">0.0.14" ]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-hyperloglog==0.0.14
+hyperloglog==0.0.14 # must not be changed, to avoid serialization errors, see #15
 isoweek==1.3.3
 mrjob==0.7.4
-tldextract==5.1.2
+tldextract==5.3.1
 ujson==5.13.0
 
 # tests


### PR DESCRIPTION
Add GitHub Dependabot configuration for
- GitHub workflow actions
- pip-managed dependencies
  - Upgrade tldextract to 5.3.1 which is actually used (deployed on Hadoop cluster).
  - Pin hyperloglog to 0.0.14